### PR TITLE
Update .eslintrc

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,11 +1,23 @@
 {
-  "extends": "airbnb-base",
-  "rules": {
-    "linebreak-style": [
-      "error",
-      "windows"
-    ],
-    "indent": [2, "tab"],
-	"no-tabs": 0
-  }
+	"extends": "airbnb-base",
+	"rules": {
+		"comma-dangle": 0,
+		"consistent-return": 0,
+		"default-case": 0,
+		"class-methods-use-this": 0,
+		"one-var": 0,
+		"linebreak-style": [
+			"error",
+			"windows"
+		],
+		"indent": [2, "tab"],
+		"no-tabs": 0
+	},
+	"env": {
+		"browser": true
+	},
+	"globals": {
+		"window": true,
+		"document": true
+	}
 }


### PR DESCRIPTION
Changelog:
1. Disabled "comma-dangle" (trailing comma expectation);
2. Disabled "consistent-return";
3. Disabled "default-case" (default expectation in switch-case. Can lead to "unreachable code");
4. Disabled "class-methods-use-this";
5. Disabled "one-var" (notification about joined vars definitions);
6. Added env for browser and default browser's globals: window and document. Prevents multiple "undefined variable" notifications.